### PR TITLE
ci: fix codecov error

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,6 +103,7 @@ jobs:
     needs: build
 
     steps:
+    - uses: actions/checkout@v4
     - name: Download coverage artifact
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
> There is an error processing the coverage reports. Common issues are [files paths](https://docs.codecov.com/docs/fixing-paths), empty files or expired reports. See error [reference](https://docs.codecov.com/docs/error-reference) page for additional troubleshooting to resolve error.